### PR TITLE
Fixes for user messages when authenticating

### DIFF
--- a/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/authn/BankIdService.java
+++ b/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/authn/BankIdService.java
@@ -1,8 +1,29 @@
+/*
+ * Copyright 2023 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package se.swedenconnect.bankid.idp.authn;
 
-import lombok.AllArgsConstructor;
-import org.springframework.core.annotation.Order;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
 import reactor.core.publisher.Mono;
 import se.swedenconnect.bankid.idp.ApiResponseFactory;
 import se.swedenconnect.bankid.idp.authn.context.BankIdContext;
@@ -18,97 +39,94 @@ import se.swedenconnect.bankid.rpapi.types.OrderResponse;
 import se.swedenconnect.bankid.rpapi.types.Requirement;
 import se.swedenconnect.spring.saml.idp.authentication.Saml2UserAuthenticationInputToken;
 
-import javax.servlet.http.HttpServletRequest;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Base64;
-import java.util.Optional;
-
 @Service
 @AllArgsConstructor
 public class BankIdService {
 
   private final BankIdEventPublisher eventPublisher;
 
-  public Mono<ApiResponse> poll(HttpServletRequest request, Boolean qr, BankIdSessionState state, Saml2UserAuthenticationInputToken authnInputToken, BankIdContext bankIdContext, BankIDClient client, String message) {
+  public Mono<ApiResponse> poll(final HttpServletRequest request, final Boolean qr, final BankIdSessionState state,
+      final Saml2UserAuthenticationInputToken authnInputToken, final BankIdContext bankIdContext,
+      final BankIDClient client, final UserVisibleData message) {
     return Optional.ofNullable(state)
         .map(BankIdSessionState::getBankIdSessionData)
-        .map(sessionData -> collect(request, client, sessionData)
+        .map(sessionData -> this.collect(request, client, sessionData)
             .map(c -> BankIdSessionData.of(sessionData, c))
-            .flatMap(b -> reAuthIfExpired(request, state, bankIdContext, client))
+            .flatMap(b -> this.reAuthIfExpired(request, state, bankIdContext, client, message))
             .map(b -> ApiResponseFactory.create(b, client.getQRGenerator(), qr))
             .onErrorResume(this::handleError))
-        .orElseGet(() -> onNoSession(request, qr, bankIdContext, client, message));
+        .orElseGet(() -> this.onNoSession(request, qr, bankIdContext, client, message));
   }
 
-  public Mono<Void> cancel(HttpServletRequest request, BankIdSessionState state, BankIDClient client) {
-    eventPublisher.orderCancellation(request).publish();
+  public Mono<Void> cancel(final HttpServletRequest request, final BankIdSessionState state,
+      final BankIDClient client) {
+    this.eventPublisher.orderCancellation(request).publish();
     return client.cancel(state.getBankIdSessionData().getOrderReference());
   }
 
-  private Mono<OrderResponse> auth(final HttpServletRequest request, String personalNumber, BankIDClient client, Boolean showQr, String message) {
-    Requirement requirement = new Requirement();
+  private Mono<OrderResponse> auth(final HttpServletRequest request, final String personalNumber,
+      final BankIDClient client, final Boolean showQr, final UserVisibleData message) {
+    final Requirement requirement = new Requirement();
     // TODO: 2023-05-17 Requirement factory per entityId
-    UserVisibleData userVisibleData = new UserVisibleData();
-    userVisibleData.setUserVisibleData(new String(Base64.getEncoder().encode(message.getBytes()), StandardCharsets.UTF_8));
-    return client.authenticate(personalNumber, request.getRemoteAddr(), userVisibleData, requirement)
+    return client.authenticate(personalNumber, request.getRemoteAddr(), message, requirement)
         .map(o -> {
-          eventPublisher.orderResponse(request, o, showQr).publish();
+          this.eventPublisher.orderResponse(request, o, showQr).publish();
           return o;
         });
   }
 
-  private Mono<OrderResponse> init(BankIdContext bankIdContext, HttpServletRequest request, BankIDClient client, boolean qr, String message) {
+  private Mono<OrderResponse> init(final BankIdContext bankIdContext, final HttpServletRequest request,
+      final BankIDClient client, final boolean qr, final UserVisibleData message) {
     if (bankIdContext.getOperation().equals(BankIdOperation.SIGN)) {
-      DataToSign dataToSign = new DataToSign();
-      dataToSign.setUserVisibleData(new String(message.getBytes()));
-      return client.sign(bankIdContext.getPersonalNumber(), request.getRemoteAddr(), dataToSign, new Requirement())
+      return client
+          .sign(bankIdContext.getPersonalNumber(), request.getRemoteAddr(), (DataToSign) message, new Requirement())
           .map(o -> {
-            eventPublisher.orderResponse(request, o, qr).publish();
+            this.eventPublisher.orderResponse(request, o, qr).publish();
             return o;
           });
     }
-    return auth(request, bankIdContext.getPersonalNumber(), client, qr, message);
+    return this.auth(request, bankIdContext.getPersonalNumber(), client, qr, message);
   }
 
-  private Mono<ApiResponse> onNoSession(HttpServletRequest request, Boolean qr, BankIdContext bankIdContext, BankIDClient client, String message) {
-    return init(bankIdContext, request, client, qr, message)
+  private Mono<ApiResponse> onNoSession(final HttpServletRequest request, final Boolean qr,
+      final BankIdContext bankIdContext, final BankIDClient client, final UserVisibleData message) {
+    return this.init(bankIdContext, request, client, qr, message)
         .map(b -> BankIdSessionData.of(b, qr))
         .flatMap(b -> collect(request, client, b)
             .map(c -> ApiResponseFactory.create(BankIdSessionData.of(b, c), client.getQRGenerator(), qr)));
-    }
-
-    private Mono<ApiResponse> handleError (Throwable e){
-      if (e instanceof BankIdSessionExpiredException bankIdSessionExpiredException) {
-        return this.sessionExpired(bankIdSessionExpiredException.getExpiredSessionHolder());
-      }
-      return Mono.error(e);
-    }
-
-    private Mono<BankIdSessionData> reAuthIfExpired (HttpServletRequest request, BankIdSessionState state, BankIdContext
-    bankIdContext, BankIDClient client){
-      BankIdSessionData bankIdSessionData = state.getBankIdSessionData();
-      if (bankIdSessionData.getExpired()) {
-        if (Duration.between(state.getInitialOrderTime(), Instant.now()).toMinutes() >= 3) {
-          return Mono.error(new BankIdSessionExpiredException(request));
-        }
-        return auth(request, bankIdContext.getPersonalNumber(), client, bankIdSessionData.getShowQr(), "Text")
-            .map(orderResponse -> BankIdSessionData.of(orderResponse, bankIdSessionData.getShowQr()));
-      }
-      return Mono.just(bankIdSessionData);
-    }
-
-    private Mono<CollectResponse> collect (HttpServletRequest request, BankIDClient client, BankIdSessionData data){
-      return client.collect(data.getOrderReference())
-          .map(c -> {
-            eventPublisher.collectResponse(request, c).publish();
-            return c;
-          });
-    }
-
-    private Mono<ApiResponse> sessionExpired (HttpServletRequest request){
-      eventPublisher.orderCancellation(request).publish();
-      return Mono.just(ApiResponseFactory.createErrorResponseTimeExpired());
-    }
   }
+
+  private Mono<ApiResponse> handleError(final Throwable e) {
+    if (e instanceof final BankIdSessionExpiredException bankIdSessionExpiredException) {
+      return this.sessionExpired(bankIdSessionExpiredException.getExpiredSessionHolder());
+    }
+    return Mono.error(e);
+  }
+
+  private Mono<BankIdSessionData> reAuthIfExpired(final HttpServletRequest request, final BankIdSessionState state,
+      final BankIdContext bankIdContext, final BankIDClient client, final UserVisibleData message) {
+    final BankIdSessionData bankIdSessionData = state.getBankIdSessionData();
+    if (bankIdSessionData.getExpired()) {
+      if (Duration.between(state.getInitialOrderTime(), Instant.now()).toMinutes() >= 3) {
+        return Mono.error(new BankIdSessionExpiredException(request));
+      }
+      return this.auth(request, bankIdContext.getPersonalNumber(), client, bankIdSessionData.getShowQr(), message)
+          .map(orderResponse -> BankIdSessionData.of(orderResponse, bankIdSessionData.getShowQr()));
+    }
+    return Mono.just(bankIdSessionData);
+  }
+
+  private Mono<CollectResponse> collect(final HttpServletRequest request, final BankIDClient client,
+      final BankIdSessionData data) {
+    return client.collect(data.getOrderReference())
+        .map(c -> {
+          this.eventPublisher.collectResponse(request, c).publish();
+          return c;
+        });
+  }
+
+  private Mono<ApiResponse> sessionExpired(final HttpServletRequest request) {
+    this.eventPublisher.orderCancellation(request).publish();
+    return Mono.just(ApiResponseFactory.createErrorResponseTimeExpired());
+  }
+}

--- a/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/authn/DisplayText.java
+++ b/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/authn/DisplayText.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.bankid.idp.authn;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Class that represents text to be displayed for the user (during authenticate or sign).
+ * 
+ * @author Martin Lindström
+ * @author Felix Hellman
+ */
+public class DisplayText {
+
+  /**
+   * Format of the display text.
+   */
+  public static enum TextFormat {
+
+    /**
+     * Plain text.
+     */
+    PLAIN_TEXT,
+
+    /**
+     * Simple Markdown v1 according to https://www.bankid.com/utvecklare/guider/formatera-text.
+     */
+    SIMPLE_MARKDOWN_V1;
+  }
+
+  /**
+   * The text.
+   */
+  @Getter
+  @Setter
+  private String text;
+
+  /**
+   * The format (defaults to {@link TextFormat#PLAIN_TEXT}.
+   */
+  @Getter
+  @Setter
+  private TextFormat format = TextFormat.PLAIN_TEXT;
+
+}

--- a/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/config/BankIdConfiguration.java
+++ b/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/config/BankIdConfiguration.java
@@ -165,7 +165,8 @@ public class BankIdConfiguration {
       final BankIDClient client =
           new BankIDClientImpl(rp.getId(), webClientFactory.createInstance(), qrGenerator);
 
-      relyingParties.add(new RelyingPartyData(client, rp.getEntityIds()));
+      relyingParties.add(new RelyingPartyData(client, rp.getEntityIds(),
+          rp.getUserMessage().getLoginText(), rp.getUserMessage().getFallbackSignText()));
     }
     return new InMemoryRelyingPartyRepository(relyingParties);
   }
@@ -211,7 +212,7 @@ public class BankIdConfiguration {
           .authnRequestProcessor(c -> c.authenticationProvider(
               pc -> pc.signatureMessagePreprocessor(signMessageProcessor)))
           .idpMetadataEndpoint(mdCustomizer -> {
-            mdCustomizer.entityDescriptorCustomizer(this.metadataCustomizer());            
+            mdCustomizer.entityDescriptorCustomizer(this.metadataCustomizer());
           })
           .userAuthentication(c -> {
             c.attributeProducers(producers -> {

--- a/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/rp/RelyingPartyData.java
+++ b/bankid-idp/bankid-idp-backend/src/main/java/se/swedenconnect/bankid/idp/rp/RelyingPartyData.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import se.swedenconnect.bankid.idp.authn.DisplayText;
 import se.swedenconnect.bankid.rpapi.service.BankIDClient;
 
 /**
@@ -40,13 +41,22 @@ public class RelyingPartyData {
    */
   private final BankIDClient client;
 
+  /** The text to display when authenticating. May be {@code null}. */
+  private final DisplayText loginText;
+
+  /** The text to display when signing if a {@code SignMessage} is not received. */
+  private final DisplayText fallbackSignText;
+
   // TODO: custom display texts, custom logo ...
 
-  public RelyingPartyData(final BankIDClient client, final List<String> entityIds) {
+  public RelyingPartyData(final BankIDClient client, final List<String> entityIds,
+      final DisplayText loginText, final DisplayText fallbackSignText) {
     this.client = Objects.requireNonNull(client, "client must not be null");
     this.entityIds = Optional.ofNullable(entityIds)
         .map(Collections::unmodifiableList)
         .orElseGet(Collections::emptyList);
+    this.loginText = loginText;
+    this.fallbackSignText = Objects.requireNonNull(fallbackSignText, "fallbackSignText must not be null");
   }
 
   /**
@@ -77,6 +87,24 @@ public class RelyingPartyData {
    */
   public List<String> getEntityIds() {
     return this.entityIds;
+  }
+
+  /**
+   * Gets text to display when authenticating.
+   * 
+   * @return the text or {@code null}
+   */
+  public DisplayText getLoginText() {
+    return this.loginText;
+  }
+
+  /**
+   * Gets the text to display when signing if a {@code SignMessage} is not received.
+   * 
+   * @return the sign text
+   */
+  public DisplayText getFallbackSignText() {
+    return this.fallbackSignText;
   }
 
   /**

--- a/bankid-idp/bankid-idp-backend/src/main/resources/application.yml
+++ b/bankid-idp/bankid-idp-backend/src/main/resources/application.yml
@@ -30,6 +30,13 @@ bankid:
   qr-code:
     size: 300
     image-format: PNG
+  user-message-defaults:
+    fallback-sign-text:
+      text: "Jag skriver härmed under den information som visades på föregående sida." 
+      format: plain-text
+    login-text:
+      text: "*Tänk på!* Logga aldrig in med ditt BankID då någon ringer och ber dig logga in."
+      format: simple-markdown-v1
   authn:
     resume-path: /resume 
     provider-name: "BankID"
@@ -138,6 +145,12 @@ bankid:
       alias: "1"
       password: "qwerty123"
       type: "PKCS12"
+    user-message:
+      inherit-default-login-text: false
+      login-text:
+        text: "Jag loggar härmed in till tjänsten Testa ditt eID.\n\n*Tänk på!* Logga aldrig in med ditt BankID då någon ringer och ber dig logga in."
+        format: simple-markdown-v1
+      
 
 saml:
   idp:
@@ -176,6 +189,8 @@ bankid:
       alias: "1"
       password: "qwerty123"
       type: "PKCS12"
+    user-message:
+      inherit-default-login-text: false
 
 saml:
   idp:


### PR DESCRIPTION
It is now configurable per RP with a catch-all default message.

@felix-hellman We should consider calculating the message at init and add it to the context instead of getting it each time.

Closes #17 