### PR TITLE
Adds Optional Links to Content Overrides

### DIFF
--- a/bankid-idp/env/local/overrides/custom.content
+++ b/bankid-idp/env/local/overrides/custom.content
@@ -1,8 +1,16 @@
 [
-    {
-        "title":"custom.devel-version.title",
-        "text":"custom.devel-version.text",
-        "position":"ABOVE",
-        "type":"INFO"
-    }
+  {
+    "title": "custom.devel-version.title",
+    "content": [
+      {
+        "text": "custom.devel-version.text"
+      },
+      {
+        "text": "custom.devel.link.text",
+        "link": "https://www.bankid.com/utvecklare/test/skaffa-testbankid/test-bankid-get"
+      }
+    ],
+    "position": "ABOVE",
+    "type": "INFO"
+  }
 ]

--- a/bankid-idp/env/local/overrides/custom.messages
+++ b/bankid-idp/env/local/overrides/custom.messages
@@ -9,8 +9,15 @@
   {
     "code" : "custom.devel-version.text",
     "text": {
-      "sv": "Detta är en lokal utvecklingsversion av BankID IdP:n",
-      "en": "This is a local development version of the BankID IdP"
+      "sv": "Detta är en lokal utvecklingsversion av BankID IdP:n och du behöver ett BankID för test för att kunna använda den",
+      "en": "This is a local development version of the BankID IdP and you will need a BankID for test in order to use it"
+    }
+  },
+  {
+    "code": "custom.devel.link.text",
+    "text": {
+      "sv": "Skaffa Test BankID",
+      "en": "Get Test BankID"
     }
   }
 ]

--- a/bankid-idp/env/local/overrides/custom.messages
+++ b/bankid-idp/env/local/overrides/custom.messages
@@ -16,8 +16,8 @@
   {
     "code": "custom.devel.link.text",
     "text": {
-      "sv": "Skaffa Test BankID",
-      "en": "Get Test BankID"
+      "sv": "Skaffa BankID för test",
+      "en": "Get BankID for test"
     }
   }
 ]

--- a/bankid-idp/src/main/frontend/.eslintrc.cjs
+++ b/bankid-idp/src/main/frontend/.eslintrc.cjs
@@ -1,0 +1,15 @@
+/* eslint-env node */
+require('@rushstack/eslint-patch/modern-module-resolution');
+
+module.exports = {
+  root: true,
+  extends: [
+    'plugin:vue/vue3-essential',
+    'eslint:recommended',
+    '@vue/eslint-config-typescript',
+    '@vue/eslint-config-prettier/skip-formatting',
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+  },
+};

--- a/bankid-idp/src/main/frontend/.prettierrc.json
+++ b/bankid-idp/src/main/frontend/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "endOfLine": "lf",
+  "printWidth": 120,
+  "bracketSameLine": false,
+  "vueIndentScriptAndStyle": true
+}

--- a/bankid-idp/src/main/frontend/src/components/CustomContent.vue
+++ b/bankid-idp/src/main/frontend/src/components/CustomContent.vue
@@ -14,7 +14,11 @@
 <template>
   <div v-if="matchingContent" :class="matchingContent.type.toLowerCase()">
     <h3>{{ $t(matchingContent.title) }}</h3>
-    <p>{{ $t(matchingContent.text) }}</p>
+      <span v-for="(item, index) in matchingContent.content">
+        <a v-if="item.link" :href=item.link >{{ $t(item.text) }}</a>
+        <p v-else>{{ $t(item.text) }}</p>
+      </span>
+    <div> <!-- Empty --> </div>
   </div>
 </template>
 

--- a/bankid-idp/src/main/frontend/src/components/CustomContent.vue
+++ b/bankid-idp/src/main/frontend/src/components/CustomContent.vue
@@ -12,32 +12,34 @@
 </script>
 
 <template>
-  <div v-if="matchingContent" :class="matchingContent.type.toLowerCase()">
+  <aside v-if="matchingContent" :class="matchingContent.type.toLowerCase()">
     <h3>{{ $t(matchingContent.title) }}</h3>
-      <span v-for="(item, index) in matchingContent.content">
-        <a v-if="item.link" :href=item.link >{{ $t(item.text) }}</a>
-        <p v-else>{{ $t(item.text) }}</p>
-      </span>
-    <div> <!-- Empty --> </div>
-  </div>
+    <p v-for="item in matchingContent.content" :key="item.text">
+      <a v-if="item.link" :href="item.link">{{ $t(item.text) }}</a>
+      <span v-else>{{ $t(item.text) }}</span>
+    </p>
+  </aside>
 </template>
 
 <style scoped>
-  div {
+  aside {
     padding: 0 1em;
     margin: 1em 0;
   }
-  div.info {
+  aside.info {
     background-color: var(--info-bg-color);
     color: var(--info-fg-color);
     border: 1px solid var(--info-border-color);
   }
-  div.warning {
+  aside.warning {
     background-color: var(--warning-bg-color);
     color: var(--warning-fg-color);
     border: 1px solid var(--warning-border-color);
   }
   h3 {
     margin-bottom: 0;
+  }
+  a {
+    font-size: 1em;
   }
 </style>

--- a/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/overrides/ContentEntry.java
+++ b/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/overrides/ContentEntry.java
@@ -1,0 +1,30 @@
+package se.swedenconnect.bankid.idp.authn.api.overrides;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ContentEntry {
+  /** Constructor
+   *
+   * @param text the message code for the text that should appear in the alert box
+   * @param link optional link, if set the text should be handled as link text
+   */
+  public ContentEntry(String text, String link) {
+    this.text = text;
+    this.link = link;
+  }
+
+  /**
+   * The message code for the text that should appear in the alert box.
+   */
+  @Getter
+  @Setter
+  private String text;
+
+  /**
+   * Optional link for the alert box
+   */
+  @Getter
+  @Setter
+  private String link;
+}

--- a/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/overrides/ContentOverride.java
+++ b/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/overrides/ContentOverride.java
@@ -15,6 +15,7 @@
  */
 package se.swedenconnect.bankid.idp.authn.api.overrides;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -71,13 +72,6 @@ public class ContentOverride {
   private String title;
 
   /**
-   * The message code for the text that should appear in the alert box.
-   */
-  @Getter
-  @Setter
-  private String text;
-
-  /**
    * The type of alert box.
    */
   @Getter
@@ -91,6 +85,9 @@ public class ContentOverride {
   @Setter
   private Position position;
 
+  @Getter
+  @Setter
+  private List<ContentEntry> content;
   /**
    * Default constructor.
    */
@@ -101,19 +98,22 @@ public class ContentOverride {
    * Constructor.
    *
    * @param title the message code for the title of the alert box
-   * @param text the message code for the text that should appear in the alert box
+   * @param content list of messages that may include an optional link
    * @param type the type of alert box
    * @param position the position of the alert box
    */
-  public ContentOverride(final String title, final String text, final Type type, final Position position) {
+  public ContentOverride(final String title, final List<ContentEntry> content, final Type type, final Position position) {
     this.title = Optional.ofNullable(title)
         .filter(StringUtils::hasText)
-        .orElseThrow(() -> new IllegalArgumentException("title must be set"));
-    this.text = Optional.ofNullable(text)
-        .filter(StringUtils::hasText)
-        .orElseThrow(() -> new IllegalArgumentException("text must be set"));
-    this.type = Objects.requireNonNull(type, "type must be set");
-    this.position = Objects.requireNonNull(position, "position must be set");
+        .orElseThrow(() -> new IllegalArgumentException("Title must be set"));
+    this.content = Optional.ofNullable(content)
+            .orElseThrow(() -> new IllegalArgumentException("Content must be set"));
+    boolean textSet = this.content.stream().allMatch(c -> Objects.nonNull(c.getText()));
+    if (!textSet) {
+      throw new IllegalArgumentException("Text must be set for every entry");
+    }
+    this.type = Objects.requireNonNull(type, "Type must be set");
+    this.position = Objects.requireNonNull(position, "Position must be set");
   }
 
 }

--- a/docs/override.md
+++ b/docs/override.md
@@ -122,8 +122,11 @@ To show an informational alert box on top of the main content using the custom m
   }
 ]
 ```
+Please note that each content-element will become a paragraph.
 
-You can also include links in the alert boxes
+
+You can also include links in the alert boxes.
+If the content element contains a "link" element, the "text" element will be used as the link text.
 ```json
 [
   {

--- a/docs/override.md
+++ b/docs/override.md
@@ -110,12 +110,36 @@ To show an informational alert box on top of the main content using the custom m
 
 ```json
 [
-    {
-        "title":"my.nocall.title",
-        "text":"my.nocall.text",
-        "position":"ABOVE",
-        "type":"INFO"
-    }
+  {
+    "title": "my.nocall.title",
+    "content": [
+      {
+        "text": "my.nocall.text"
+      }
+    ],
+    "position": "ABOVE",
+    "type": "INFO"
+  }
+]
+```
+
+You can also include links in the alert boxes
+```json
+[
+  {
+    "title": "custom.devel-version.title",
+    "content": [
+      {
+        "text": "custom.devel-version.text"
+      },
+      {
+        "text": "custom.devel.link.text",
+        "link": "https://www.bankid.com/utvecklare/test/skaffa-testbankid/test-bankid-get"
+      }
+    ],
+    "position": "ABOVE",
+    "type": "INFO"
+  }
 ]
 ```
 


### PR DESCRIPTION
<img width="677" alt="Screenshot 2023-09-20 at 14 36 25" src="https://github.com/swedenconnect/bankid-saml-idp/assets/12511470/5252a9d0-9a04-468d-82d3-0434e1d5f2ab">

This is working but I had to do some ugly hacks in frontend to get everything to align properly @oestrogen maybe you can improve on my non-optimal solution?