### PR TITLE
Adds missing collect api call on reinit

### DIFF
--- a/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/service/BankIdService.java
+++ b/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/service/BankIdService.java
@@ -201,7 +201,11 @@ public class BankIdService {
         return Mono.error(new BankIdSessionExpiredException(request));
       }
       return this.init(request)
-          .map(orderResponse -> BankIdSessionData.of(request, orderResponse));
+          .map(orderResponse -> BankIdSessionData.of(request, orderResponse))
+              .flatMap(b -> request.getRelyingPartyData().getClient().collect(b.getOrderReference())
+                      .map(c -> {
+                        return BankIdSessionData.of(state.getBankIdSessionData(), c);
+                      }));
     }
     else {
       return Mono.just(bankIdSessionData);


### PR DESCRIPTION
Without this when polling, we will have one frame without a qr code in between reinit and the next poll.

Closes #142 