### PR TITLE
Fixes endless autostart on iPhone with Safari

### DIFF
--- a/bankid-frontend/__tests__/AutoStartLinkFactory.test.ts
+++ b/bankid-frontend/__tests__/AutoStartLinkFactory.test.ts
@@ -16,7 +16,7 @@ const testArguments = [
     userAgent:
       'Mozilla/5.0 (Linux; Android 12; SM-S906N Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.119 Mobile Safari/537.36',
     device: 'android-phone',
-    link: 'https://app.bankid.com/?autostarttoken=token&redirect=https://location.se',
+    link: 'https://app.bankid.com/?autostarttoken=token&redirect=https://location.se#anchor',
     automaticDeviceSelect: true,
   },
   {
@@ -24,14 +24,14 @@ const testArguments = [
     userAgent:
       'Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1',
     device: 'iphone-phone',
-    link: 'https://app.bankid.com/?autostarttoken=token&redirect=https://location.se',
+    link: 'https://app.bankid.com/?autostarttoken=token&redirect=https://location.se#anchor',
     automaticDeviceSelect: true,
   },
   {
     name: 'iphone-16-3-1-mobile-safari',
     userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Mobile/15E148 Safari/604.1',
     device: 'iphone-phone',
-    link: 'https://app.bankid.com/?autostarttoken=token&redirect=https://location.se',
+    link: 'https://app.bankid.com/?autostarttoken=token&redirect=https://location.se#anchor',
     automaticDeviceSelect: true
   }
 ];

--- a/bankid-frontend/src/AutoStartLinkFactory.ts
+++ b/bankid-frontend/src/AutoStartLinkFactory.ts
@@ -21,7 +21,7 @@ function getDefaultRedirect(token: string) {
 }
 
 function getMobileRedirect(token: string, location: string) {
-  return 'https://app.bankid.com/?autostarttoken=' + token + '&redirect=' + location;
+  return 'https://app.bankid.com/?autostarttoken=' + token + '&redirect=' + location + "#anchor";
 }
 
 export function shallSelectDeviceAutomatically(userAgent: string) {

--- a/bankid-frontend/src/views/AuthenticateView.vue
+++ b/bankid-frontend/src/views/AuthenticateView.vue
@@ -13,11 +13,14 @@
   const token = ref('');
   const messageCode = ref('');
   const responseStatus = ref<ApiResponseStatus | null>(null);
+  const hideAutoStart = ref(false);
 
   const props = defineProps<{
     uiInfo: UiInformation | null;
     otherDevice: boolean;
   }>();
+
+
 
   const showQrInstructions = computed(
     () => messageCode.value === 'bankid.msg.ext2' && props.uiInfo && props.uiInfo.displayQrHelp,
@@ -41,6 +44,7 @@
         if (response.status !== 'NOT_STARTED') {
           qrImage.value = '';
         }
+        hideAutoStart.value = response.status !== 'NOT_STARTED';
         token.value = response.autoStartToken;
         messageCode.value = response.messageCode;
 
@@ -95,7 +99,7 @@
     <CustomContent v-else position="autostart" />
     <p v-if="!showQrInstructions">{{ $t(messageCode) }}</p>
     <QrInstructions v-else />
-    <AutoStart v-if="!otherDevice && !showContinueErrorButton()" :autoStartToken="token" />
+    <AutoStart v-if="!otherDevice && !showContinueErrorButton() && !hideAutoStart" :autoStartToken="token" />
     <QrDisplay :image="qrImage" />
     <button class="btn-default" v-if="showContinueErrorButton()" @click="acceptError">
       <span>{{ $t('bankid.msg.btn-error-continue') }}</span>


### PR DESCRIPTION
Closes #163 

Regarding anchors, https://stackoverflow.com/questions/22102137/return-to-the-browser-page-that-launched-an-app-without-refreshing/24786670#24786670

I don't know if this is an undefined behaviour so I added a check to only display the autostart component if no BankID session have been consumed. If the autostart component is hidden, the client will not try autostart.