### PR TITLE
Fixes autostart not going back to chrome when used on iOS/iPhone

### DIFF
--- a/bankid-frontend/__tests__/AutoStartLinkFactory.test.ts
+++ b/bankid-frontend/__tests__/AutoStartLinkFactory.test.ts
@@ -33,6 +33,13 @@ const testArguments = [
     device: 'iphone-phone',
     link: 'https://app.bankid.com/?autostarttoken=token&redirect=https://location.se#anchor',
     automaticDeviceSelect: true
+  },
+  {
+    name: 'iphone-16-3-1-mobile-chrome',
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/117.0.5938.117 Mobile/15E148 Safari/604.1',
+    device: 'iphone-phone',
+    link: 'https://app.bankid.com/?autostarttoken=token&redirect=googlechromes://',
+    automaticDeviceSelect: true
   }
 ];
 

--- a/bankid-frontend/src/AutoStartLinkFactory.ts
+++ b/bankid-frontend/src/AutoStartLinkFactory.ts
@@ -8,6 +8,9 @@ export function createLink(userAgent: string, token: string, location: string) {
       if (ua.browser.name === 'Mobile Safari' || ua.browser.name === 'Safari') {
         return getMobileRedirect(token, location);
       }
+      if (ua.browser.name === 'Chrome') {
+        return getIphoneRedirect(token, location, ua.browser.name);
+      }
       // Unsupported browser on iphone
       return getDefaultRedirect(token);
     case 'android-phone':
@@ -50,4 +53,20 @@ export function getType(ua: UAParser.IResult) {
     }
   }
   return 'unknown';
+}
+
+function getIphoneRedirect(token: string, location: string, browser: string) {
+  let appLink = getIphoneAppLink(browser);
+  if (appLink !== "missing") {
+    return getMobileRedirect(token, appLink).replace("#anchor", "");
+  }
+  // Fallback to let the user switch app
+  return getDefaultRedirect(token);
+}
+
+function getIphoneAppLink(browser: string) {
+  if (browser === 'Chrome') {
+    return "googlechromes://";
+  }
+  return "missing";
 }


### PR DESCRIPTION
Closes #165 

When opening chrome on iOS device, we do not want to include a website to open.
If we include a website to open, this website will be opened in chrome but in a new window/tab.
If we do not include a website to open iOS will just switch back to the app to our previous tab.