### PR TITLE
Copy resources to target before building jar

### DIFF
--- a/bankid-idp/pom.xml
+++ b/bankid-idp/pom.xml
@@ -356,7 +356,7 @@
             <executions>
               <execution>
                 <id>copy-resource-templates</id>
-                <phase>package</phase>
+                <phase>prepare-package</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
@@ -374,7 +374,7 @@
               </execution>
               <execution>
                 <id>copy-resources-assets</id>
-                <phase>package</phase>
+                <phase>prepare-package</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>


### PR DESCRIPTION
Closes #185

Output after changes (jar is built after resources are copied to classpath)
 
```
[INFO] --- resources:3.3.1:copy-resources (copy-resource-templates) @ bankid-idp ---
[INFO] Copying 1 resource from target/frontend/dist to target/classes/templates
[INFO]
[INFO] --- resources:3.3.1:copy-resources (copy-resources-assets) @ bankid-idp ---
[INFO] Copying 4 resources from target/frontend/dist/assets to target/classes/static/assets
[INFO]
[INFO] --- jar:3.3.0:jar (default-jar) @ bankid-idp ---
[INFO] Building jar: /Users/felixhellman/git/bankid-saml-idp/bankid-idp/target/bankid-idp-1.0.1.jar
[INFO]
[INFO] --- spring-boot:2.7.16:repackage (repackage) @ bankid-idp ---
[INFO] Attaching repackaged archive /Users/felixhellman/git/bankid-saml-idp/bankid-idp/target/bankid-idp-1.0.1-exec.jar with classifier exec
```

