### PR TITLE
bugfix/is 235 invalid user message on misconfigured message

### DIFF
--- a/bankid-api/src/main/java/se/swedenconnect/bankid/rpapi/service/impl/BankIdErrorBodyExtractors.java
+++ b/bankid-api/src/main/java/se/swedenconnect/bankid/rpapi/service/impl/BankIdErrorBodyExtractors.java
@@ -18,8 +18,10 @@ package se.swedenconnect.bankid.rpapi.service.impl;
 import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import reactor.core.publisher.Mono;
+import se.swedenconnect.bankid.rpapi.types.ErrorCode;
 
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.function.Function;
 /**
  * Body Extractors for BankIdErrors
@@ -36,6 +38,10 @@ public class BankIdErrorBodyExtractors {
   public static Function<ClientResponse, Mono<? extends Throwable>> userErrorBodyExtractor() {
     return c -> {
       return c.body(BodyExtractors.toMono(HashMap.class)).map(m -> {
+        final String errorCode = (String) m.get("errorCode");
+        if (Objects.nonNull(errorCode)) {
+          return new BankIdUserException(ErrorCode.forValue(errorCode), "Error to communicate with BankID API response:" + m.toString());
+        }
         return new BankIdUserException("Error to communicate with BankID API response:" + m.toString());
       });
     };
@@ -48,6 +54,10 @@ public class BankIdErrorBodyExtractors {
   public static Function<ClientResponse, Mono<? extends Throwable>> serverErrorBodyExtractor() {
     return c -> {
       return c.body(BodyExtractors.toMono(HashMap.class)).map(m -> {
+        final String errorCode = (String) m.get("errorCode");
+        if (Objects.nonNull(errorCode)) {
+          return new BankIdUserException(ErrorCode.forValue(errorCode), "Error to communicate with BankID API response:" + m.toString());
+        }
         return new BankIdServerException("Error to communicate with BankID API response:" + m.toString());
       });
     };

--- a/bankid-api/src/main/java/se/swedenconnect/bankid/rpapi/service/impl/BankIdUserException.java
+++ b/bankid-api/src/main/java/se/swedenconnect/bankid/rpapi/service/impl/BankIdUserException.java
@@ -17,6 +17,7 @@ package se.swedenconnect.bankid.rpapi.service.impl;
 
 import se.swedenconnect.bankid.rpapi.LibraryVersion;
 import se.swedenconnect.bankid.rpapi.types.BankIDException;
+import se.swedenconnect.bankid.rpapi.types.ErrorCode;
 
 /**
  * Exception class for 4XX API errors.
@@ -38,4 +39,7 @@ public class BankIdUserException extends BankIDException {
     super(message);
   }
 
+  public BankIdUserException(ErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
 }

--- a/bankid-idp/env/local/developer.yml
+++ b/bankid-idp/env/local/developer.yml
@@ -187,28 +187,3 @@ spring:
             to: "redis2.local.dev.swedenconnect.se:2002"
           - from: "172.20.0.33:2003"
             to: "redis3.local.dev.swedenconnect.se:2003"
----
-spring:
-  config:
-    activate:
-      on-profile: invalid-message
-bankid:
-  relying-parties:
-    - id: test-my-eid
-      entity-ids:
-        - http://sandbox.swedenconnect.se/testmyeid
-        - http://sandbox.swedenconnect.se/testmyeid-sign
-      credential:
-        name: "test-cred"
-        resource: file:${BANKID_INSTALL_DIR}/bankid-idp/env/swedenconnect/sandbox/certificate/FPTestcert4_20220818.p12
-        alias: "1"
-        password: "qwerty123"
-        type: "PKCS12"
-      user-message:
-        inherit-default-login-text: false
-        login-text:
-          text: "Du loggar nu in till en utländsk e-tjänst.\nVi delar följande data om dig:\n+ Ditt personnummer\n+Ditt för- och efternamn"
-          format: simple-markdown-v1
-      bankid-requirements:
-        pin-code-auth: false
-        pin-code-sign: true

--- a/bankid-idp/env/local/developer.yml
+++ b/bankid-idp/env/local/developer.yml
@@ -187,4 +187,28 @@ spring:
             to: "redis2.local.dev.swedenconnect.se:2002"
           - from: "172.20.0.33:2003"
             to: "redis3.local.dev.swedenconnect.se:2003"
-
+---
+spring:
+  config:
+    activate:
+      on-profile: invalid-message
+bankid:
+  relying-parties:
+    - id: test-my-eid
+      entity-ids:
+        - http://sandbox.swedenconnect.se/testmyeid
+        - http://sandbox.swedenconnect.se/testmyeid-sign
+      credential:
+        name: "test-cred"
+        resource: file:${BANKID_INSTALL_DIR}/bankid-idp/env/swedenconnect/sandbox/certificate/FPTestcert4_20220818.p12
+        alias: "1"
+        password: "qwerty123"
+        type: "PKCS12"
+      user-message:
+        inherit-default-login-text: false
+        login-text:
+          text: "Du loggar nu in till en utländsk e-tjänst.\nVi delar följande data om dig:\n+ Ditt personnummer\n+Ditt för- och efternamn"
+          format: simple-markdown-v1
+      bankid-requirements:
+        pin-code-auth: false
+        pin-code-sign: true

--- a/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/ApiResponseFactory.java
+++ b/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/ApiResponseFactory.java
@@ -92,4 +92,14 @@ public class ApiResponseFactory {
   public static ApiResponse createUserCancelResponse() {
     return new ApiResponse(ApiResponse.Status.CANCEL, "", "", "bankid.msg.error.userCancel");
   }
+
+  /**
+   * Creates an {@link ApiResponse} representing an unknown error.
+   * This does not necessarily mean that the error is unknown but should not be presented to the user.
+   *
+   * @return an {@link ApiResponse}
+   */
+  public static ApiResponse createUnknownError() {
+    return new ApiResponse(ApiResponse.Status.ERROR, "", "", "bankid.msg.error.unknown");
+  }
 }

--- a/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/BankIdApiController.java
+++ b/bankid-idp/src/main/java/se/swedenconnect/bankid/idp/authn/api/BankIdApiController.java
@@ -50,7 +50,9 @@ import se.swedenconnect.bankid.idp.rp.RelyingPartyRepository;
 import se.swedenconnect.bankid.rpapi.service.BankIDClient;
 import se.swedenconnect.bankid.rpapi.service.UserVisibleData;
 import se.swedenconnect.bankid.rpapi.service.impl.BankIdServerException;
+import se.swedenconnect.bankid.rpapi.service.impl.BankIdUserException;
 import se.swedenconnect.bankid.rpapi.types.BankIDException;
+import se.swedenconnect.bankid.rpapi.types.ErrorCode;
 import se.swedenconnect.bankid.rpapi.types.ProgressStatus;
 import se.swedenconnect.opensaml.sweid.saml2.attribute.AttributeConstants;
 import se.swedenconnect.opensaml.sweid.saml2.metadata.entitycategory.EntityCategoryConstants;
@@ -143,8 +145,8 @@ public class BankIdApiController {
       return this.service.poll(pollRequest)
           .onErrorResume(e -> e instanceof BankIdServerException,
               e -> Mono.just(ApiResponseFactory.createErrorResponseBankIdServerException()))
-          .onErrorResume(e -> e instanceof BankIDException,
-              e -> Mono.just(ApiResponseFactory.createErrorResponseTimeExpired()));
+          .onErrorResume(e -> e instanceof BankIdUserException && ((BankIdUserException) e).getErrorCode() == ErrorCode.INVALID_PARAMETERS, e -> Mono.just(ApiResponseFactory.createUnknownError()))
+          .onErrorResume(e -> e instanceof BankIDException, e -> Mono.just(ApiResponseFactory.createErrorResponseTimeExpired()));
     }
   }
 


### PR DESCRIPTION
Fixes #235 

<img width="688" alt="Screenshot 2023-12-19 at 09 54 16" src="https://github.com/swedenconnect/bankid-saml-idp/assets/12511470/ba6d3c3e-9b36-4f6c-9125-a420ec1c82b8">

Adds default user error message when the IDP is missconfigured to send invalid message data to bankid-api